### PR TITLE
 Await the next middleware

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,7 @@ dlldata.c
 project.lock.json
 project.fragment.lock.json
 artifacts/
-**/Properties/launchSettings.json
+#**/Properties/launchSettings.json
 
 *_i.c
 *_p.c

--- a/Test.RestApi/Controllers/ValuesController.cs
+++ b/Test.RestApi/Controllers/ValuesController.cs
@@ -30,15 +30,22 @@ namespace Test.RestApi
         public async Task<IActionResult> Post([FromBody]RequestDto requestDto)
         {
             m_Logger.Information($"{nameof(Post)} Invoked");
+
+            // Ensure this actiuon is truly asyncronious.
+            await Task.Yield();
+
             if (!ModelState.IsValid)
             {
                 return BadRequest(ModelState);
             }
             try
             {
+                await Task.Yield();
                 string result = await m_ValueAccess.AddAsync(requestDto).ConfigureAwait(false);
                 if (!string.IsNullOrWhiteSpace(result))
                 {
+
+                    m_Logger.Information($"{nameof(Post)} Completed");
                     return Ok(result);
                 }
             }
@@ -53,9 +60,15 @@ namespace Test.RestApi
         public async Task<IActionResult> Get()
         {
             m_Logger.Information($"{nameof(Get)} Invoked");
+
+            // Ensure this actiuon is truly asyncronious.
+            await Task.Yield();
+
             try
             {
                 IList<ResponseDto> responses = await m_ValueAccess.GetAsync(Guid.NewGuid().ToString(), "Password123!").ConfigureAwait(false);
+
+                m_Logger.Information($"{nameof(Get)} Completed");
                 return Ok(responses);
             }
             catch (Exception ex)

--- a/Test.RestApi/Properties/launchSettings.json
+++ b/Test.RestApi/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:53272/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "launchUrl": "swagger/",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Test.RestApi": {
+      "commandName": "Project",
+      "launchBrowser": true,
+      "launchUrl": "swagger/",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:53273/"
+    }
+  }
+}

--- a/Zametek.Utility.Logging.AspNetCore.sln
+++ b/Zametek.Utility.Logging.AspNetCore.sln
@@ -3,9 +3,9 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.27428.2037
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Zametek.Utility.Logging.AspNetCore", "Zametek.Utility.Logging.AspNetCore\Zametek.Utility.Logging.AspNetCore.csproj", "{4F623874-428B-4730-8C7C-32E5ACC33258}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Test.RestApi", "Test.RestApi\Test.RestApi.csproj", "{16303037-F5D0-4361-B86B-0B35BAF4957D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Test.RestApi", "Test.RestApi\Test.RestApi.csproj", "{16303037-F5D0-4361-B86B-0B35BAF4957D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Zametek.Utility.Logging.AspNetCore", "Zametek.Utility.Logging.AspNetCore\Zametek.Utility.Logging.AspNetCore.csproj", "{4F623874-428B-4730-8C7C-32E5ACC33258}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -13,14 +13,14 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{4F623874-428B-4730-8C7C-32E5ACC33258}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{4F623874-428B-4730-8C7C-32E5ACC33258}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{4F623874-428B-4730-8C7C-32E5ACC33258}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{4F623874-428B-4730-8C7C-32E5ACC33258}.Release|Any CPU.Build.0 = Release|Any CPU
 		{16303037-F5D0-4361-B86B-0B35BAF4957D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{16303037-F5D0-4361-B86B-0B35BAF4957D}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{16303037-F5D0-4361-B86B-0B35BAF4957D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{16303037-F5D0-4361-B86B-0B35BAF4957D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4F623874-428B-4730-8C7C-32E5ACC33258}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4F623874-428B-4730-8C7C-32E5ACC33258}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4F623874-428B-4730-8C7C-32E5ACC33258}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4F623874-428B-4730-8C7C-32E5ACC33258}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This ensures the log context is not unwound before the next middleware is complete.

Also, a couple of other tweaks

1. Check-in the launch settings
1. Reordered the solution projects to make the test API the default